### PR TITLE
fix(example): update android compile sdk version to 28

### DIFF
--- a/Example/android/build.gradle
+++ b/Example/android/build.gradle
@@ -4,7 +4,7 @@ buildscript {
     ext {
         buildToolsVersion = "27.0.3"
         minSdkVersion = 16
-        compileSdkVersion = 27
+        compileSdkVersion = 28
         targetSdkVersion = 26
         supportLibVersion = "27.1.1"
     }


### PR DESCRIPTION
currently there's an error in build android example
https://travis-ci.org/kmagiera/react-native-gesture-handler/jobs/487897003
```
:app:processDebugResources/home/travis/.gradle/caches/transforms-1/files-1.1/appcompat-v7-28.0.0.aar/ab43ce15aa23b451992a0e8300eb99e6/res/values-v28/values-v28.xml:9:5-12:13: AAPT: error: resource android:attr/dialogCornerRadius not found.
    
/home/travis/build/kmagiera/react-native-gesture-handler/Example/android/app/build/intermediates/incremental/mergeDebugResources/merged.dir/values-v28/values-v28.xml:11: AAPT: error: resource android:attr/dialogCornerRadius not found.
    
/home/travis/.gradle/caches/transforms-1/files-1.1/appcompat-v7-28.0.0.aar/ab43ce15aa23b451992a0e8300eb99e6/res/values/values.xml:1304:5-69: AAPT: error: resource android:attr/fontVariationSettings not found.
    
/home/travis/.gradle/caches/transforms-1/files-1.1/appcompat-v7-28.0.0.aar/ab43ce15aa23b451992a0e8300eb99e6/res/values/values.xml:1304:5-69: AAPT: error: resource android:attr/ttcIndex not found.
    
error: failed linking references.
```

The solution is to update the compileSdkVersion to `28` https://github.com/crosswalk-project/cordova-plugin-crosswalk-webview/issues/207#issuecomment-424038966

--
I think the cause is because you change the react native version of the Example

https://github.com/kmagiera/react-native-gesture-handler/pull/406/files#diff-77190fabae122eec07dd4211d79a25f7R20